### PR TITLE
perf: reduce zsh startup work

### DIFF
--- a/config/zsh/zprofile.zsh
+++ b/config/zsh/zprofile.zsh
@@ -1,6 +1,12 @@
 ### Homebrew ###
-if [[ "$OSTYPE" == darwin* ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
+if [[ "$OSTYPE" == darwin* && -d /opt/homebrew ]]; then
+    export HOMEBREW_PREFIX="/opt/homebrew"
+    export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
+    export HOMEBREW_REPOSITORY="/opt/homebrew"
+    path=("$HOMEBREW_PREFIX/bin" "$HOMEBREW_PREFIX/sbin" $path)
+    fpath=("$HOMEBREW_PREFIX/share/zsh/site-functions" $fpath)
+    [[ -n "${MANPATH-}" ]] && export MANPATH=":${MANPATH#:}"
+    export INFOPATH="$HOMEBREW_PREFIX/share/info:${INFOPATH:-}"
 fi
 
 # Include $HOME/.local/bin if it exists

--- a/config/zsh/zshrc.zsh
+++ b/config/zsh/zshrc.zsh
@@ -29,7 +29,6 @@ plugins=(
     git                     # Git aliases and functions
     vi-mode                 # Basic vim-like editing
     tmux                    # Tmux aliases
-    colored-man-pages       # Use colored man pages
     #
     zsh-syntax-highlighting # Must be the last plugin!
 )
@@ -38,7 +37,36 @@ plugins=(
 # this provides addtional zsh completions
 fpath+=${ZSH_CUSTOM:-${ZSH:-~/.oh-my-zsh}/custom}/plugins/zsh-completions/src
 
-# Lazy load some plugins to boost shell startup speed
+# Cache generated completion files and let compinit autoload them on demand.
+_cache_completion() {
+    local completion_name="$1"
+    local command_name="$2"
+    shift 2
+
+    local command_path="${commands[$command_name]}"
+    [[ -n "$command_path" ]] || return 0
+
+    local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/completions"
+    local cache_file="$cache_dir/$completion_name"
+    local tmp_file="$cache_file.$$"
+
+    if [[ ! -r "$cache_file" || "$command_path" -nt "$cache_file" ]]; then
+        mkdir -p "$cache_dir" 2>/dev/null || return 0
+
+        if "$@" >| "$tmp_file" 2>/dev/null; then
+            mv "$tmp_file" "$cache_file"
+        else
+            rm -f "$tmp_file"
+            return 0
+        fi
+    fi
+
+    fpath=("$cache_dir" $fpath)
+}
+
+_cache_completion _uv uv uv generate-shell-completion zsh
+_cache_completion _uvx uvx uvx --generate-shell-completion zsh
+unfunction _cache_completion
 
 # Enable tab completion for hidden files
 _comp_options+=(globdots)
@@ -58,25 +86,23 @@ ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd history completion)
 VI_MODE_RESET_PROMPT_ON_MODE_CHANGE=true
 VI_MODE_SET_CURSOR=true
 
-# Overwrite colors set in colored-man-pages
+# Set colored man pages without loading the full colored-man-pages plugin.
+autoload -Uz colors && colors
 # bold & blinking mode
-less_termcap[mb]="${fg[green]}"
-less_termcap[md]="${fg[green]}"
-less_termcap[me]="${reset_color}"
+export LESS_TERMCAP_mb="${fg[green]}"
+export LESS_TERMCAP_md="${fg[green]}"
+export LESS_TERMCAP_me="${reset_color}"
 # standout mode
-less_termcap[so]="${fg_bold[black]}${bg[blue]}"
-less_termcap[se]="${reset_color}"
+export LESS_TERMCAP_so="${fg_bold[black]}${bg[blue]}"
+export LESS_TERMCAP_se="${reset_color}"
 # underlining
-less_termcap[us]="${fg[magenta]}"
-less_termcap[ue]="${reset_color}"
+export LESS_TERMCAP_us="${fg[magenta]}"
+export LESS_TERMCAP_ue="${reset_color}"
 # then add a progress bar to man pages by hacking less
+export GROFF_NO_SGR=1
 export MANPAGER='less --squeeze-blank-lines --long-prompt +Gg'
 
 ### general config ###
-# uv
-eval "$(uv generate-shell-completion zsh)"
-eval "$(uvx --generate-shell-completion zsh)"
-
 # fzf
 [[ -f "$HOME/.dotfiles/config/fzf.zsh" ]] && source "$HOME/.dotfiles/config/fzf.zsh"
 

--- a/config/zsh/zshrc.zsh
+++ b/config/zsh/zshrc.zsh
@@ -144,7 +144,35 @@ fi
 if [[ "$SHORT_HOST" == 'M4R5H295L2' ]]; then
     # AWS
     export AWS_PROFILE='freee-dev'
-    export ONELOGIN_MFA_IP_ADDRESS="$(curl -fsS https://checkip.amazonaws.com)"
+    _set_onelogin_mfa_ip_address() {
+        local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zsh"
+        local cache_file="$cache_dir/onelogin_mfa_ip_address"
+        local ip
+        local -a expired=("$cache_file"(Nmh+1))
+
+        if [[ -r "$cache_file" ]]; then
+            export ONELOGIN_MFA_IP_ADDRESS="$(<"$cache_file")"
+        fi
+
+        if [[ ! -r "$cache_file" ]]; then
+            if ip="$(curl -fsS --max-time 2 https://checkip.amazonaws.com 2>/dev/null)"; then
+                ip="${ip//$'\n'/}"
+                if [[ -n "$ip" ]]; then
+                    export ONELOGIN_MFA_IP_ADDRESS="$ip"
+                    mkdir -p "$cache_dir" 2>/dev/null && print -r -- "$ip" >| "$cache_file"
+                fi
+            fi
+        elif (( ${#expired} > 0 )); then
+            (
+                if ip="$(curl -fsS --max-time 2 https://checkip.amazonaws.com 2>/dev/null)"; then
+                    ip="${ip//$'\n'/}"
+                    [[ -n "$ip" ]] && mkdir -p "$cache_dir" 2>/dev/null && print -r -- "$ip" >| "$cache_file"
+                fi
+            ) &!
+        fi
+    }
+    _set_onelogin_mfa_ip_address
+    unfunction _set_onelogin_mfa_ip_address
     # GitHub
     export BUNDLE_RUBYGEMS__PKG__GITHUB__COM="$GITHUB_TOKEN_FOR_GITHUB_PACKAGES"
     export GITHUB_USERNAME="ming-hao-xu"
@@ -157,7 +185,15 @@ if [[ "$SHORT_HOST" == 'M4R5H295L2' ]]; then
     export NODE_EXTRA_CA_CERTS="$HOMEBREW_PREFIX/etc/openssl@3/certs/palo-root.pem"
     export SSL_CERT_PATH="${HOMEBREW_PREFIX}/etc/openssl@3/certs"
 
-    alias claude="fdev secrets --enable-encryption exec claude-code-flugel-custom-header -- $(which claude)"
+    claude() {
+        local claude_bin="${commands[claude]}"
+        [[ -n "$claude_bin" ]] || {
+            print "claude: command not found" >&2
+            return 127
+        }
+
+        fdev secrets --enable-encryption exec claude-code-flugel-custom-header -- "$claude_bin" "$@"
+    }
 fi
 
 # Init starship prompt


### PR DESCRIPTION
## Summary

This PR makes targeted zsh startup optimizations based on profiling, benchmarking, docs, and a quick comparison with other performance-focused dotfiles patterns:

- Cache `uv` and `uvx` generated zsh completions under `$XDG_CACHE_HOME/zsh/completions`, add that cache directory to `fpath`, and let `compinit` autoload the completion functions on demand.
- Remove the `colored-man-pages` Oh My Zsh plugin from startup and replace it with direct `LESS_TERMCAP_*` exports, preserving the configured man-page colors without loading the full plugin.
- Replace `eval "$(/opt/homebrew/bin/brew shellenv)"` in login shells with the equivalent static Apple Silicon Homebrew environment for this repo.
- Optimize the corporate `freee` block by caching the OneLogin MFA public IP lookup and by changing the `claude` alias into a wrapper function that resolves the real Claude binary only when invoked.

## Why these changes

### 1. Avoid regenerating large completions on every shell

Previously, every interactive shell ran:

```zsh
eval "$(uv generate-shell-completion zsh)"
eval "$(uvx --generate-shell-completion zsh)"
```

The official uv docs recommend these eval snippets for basic setup, but zsh's completion system is designed to discover `_name` completion files from directories on `fpath` and autoload them when completion is requested. This PR keeps uv/uvx completions available while moving generation and sourcing out of the common startup path.

References:

- uv shell autocompletion docs: https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
- zsh completion autoload docs: https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Autoloaded-files

### 2. Avoid a redundant plugin load

The config already overrides the colors from `colored-man-pages` immediately after Oh My Zsh loads. Profiling showed that this plugin was one of the most expensive individual plugins in the current set. Replacing it with direct `LESS_TERMCAP_*` exports keeps colored man pages and the existing `MANPAGER` behavior without sourcing the plugin.

### 3. Avoid login-shell Homebrew command substitution

Homebrew documents that zsh completions must be added before `compinit`, and that `brew shellenv` performs this setup. This repo is explicitly for Apple Silicon macOS and already hardcodes `/opt/homebrew`, so using the equivalent static exports avoids spawning `brew` and `path_helper` on every login shell while keeping Homebrew paths and zsh site-functions available before Oh My Zsh runs `compinit`.

Reference:

- Homebrew zsh completion docs: https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh

### 4. Avoid corporate startup network/path work

The `freee` block previously ran this on every matching host startup:

```zsh
curl -fsS https://checkip.amazonaws.com
$(which claude)
```

The public IP lookup alone costs roughly 230-250 ms in this environment and depends on network availability. The new code:

- reads a cached IP immediately when present
- refreshes stale cached IPs in the background
- performs a bounded synchronous lookup only when no cache exists yet
- changes `claude` into a function so the real binary path is resolved at call time, not at startup

## External repo check

I also checked performance-oriented dotfiles examples and plugin-manager docs. The common theme is the same direction as this PR: keep shell startup small, lazy-load or cache generated setup, and avoid doing expensive work before the prompt.

Examples:

- Z-SHIFT / zsh-bench discussion: https://www.reddit.com/r/dotfiles/comments/1r87onp/got_tired_of_redoing_my_zsh_setup_on_every/
- Zinit examples cache generated starship init/completions at clone/pull time rather than recomputing every startup: https://github.com/zdharma-continuum/zinit

I did not move this repo to a new plugin manager or rewrite the shell architecture; that would be over-engineering for this PR.

## Benchmark

Temporary-home harness, same machine, same Oh My Zsh install, warmed caches. Each run starts repeated zsh shells and reports average seconds per shell.

Login shell, default host path:

```text
before 0.25945045948028567
after  0.15993880033493041
before 0.26231395006179808
after  0.15985825061798095
```

Interactive shell with corporate block forced on, warmed corporate IP cache:

```text
before 0.53272074460983276
after  0.15754324197769165
before 0.47888660430908203
after  0.15794625878334045
```

Individual hotspot measurements before editing:

```text
uv/uvx completion eval removal       ~78 ms saved
colored-man-pages plugin removal     ~82 ms saved
curl checkip.amazonaws.com           ~230-250 ms per matching corporate startup
brew shellenv                        ~10-20 ms per login shell
```

## Validation

- `zsh -n config/zsh/zshrc.zsh config/zsh/zprofile.zsh config/zsh/zshenv.zsh config/zsh/functions.zsh config/zsh/aliases.zsh config/zsh/keybindings.zsh config/fzf.zsh`
- Started an interactive shell from a clean temporary home.
- Started a login shell from a clean temporary home and verified Homebrew path/fpath setup.
- Verified cached completion files are generated as `_uv` and `_uvx`.
- Verified zsh can autoload both completion functions with `autoload +X _uv` and `autoload +X _uvx`.
- Forced the corporate block in a temporary copy and verified `ONELOGIN_MFA_IP_ADDRESS` is set from cache after first lookup and `claude` is defined as a function.

## Notes

The benchmark harness runs inside a sandbox, so it prints existing non-TTY/sandbox warnings from Oh My Zsh and fzf in some validation commands. Those warnings existed before this change and were not used as success criteria; the timing comparison used the same harness for before and after.

I did not add a `Co-authored-by` trailer for Claude because Claude did not actually contribute to these commits. If we later run Claude on this PR and use its patch or review suggestions, I can add an accurate co-author trailer then.
