### PR TITLE
Clarify install behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Personal .dotfiles for macOS (Apple Silicon) running zsh
 
 > [!WARNING]  
-> This repository is intended for personal use and should be run on a new machine. Do not use it directly without understanding its operations. Running `./install` will *overwrite* existing dotfiles!
+> This repository is intended for personal use. Do not run it without understanding its operations. `./install` manages the configured dotfiles paths, relinks managed symlinks, removes stale repo-managed links, and may back up conflicting files or directories as `.dotbot-backup.<timestamp>`.
 
 > [!NOTE]  
 > Ensure using a login shell.  
@@ -28,16 +28,33 @@ Personal .dotfiles for macOS (Apple Silicon) running zsh
 
 1. Install dotfiles
 
-    **All packages listed in [`macos/Brewfile`](https://github.com/ming-hao-xu/dotfiles/blob/main/macos/Brewfile) will be installed.**
+    [`macos/Brewfile`](https://github.com/ming-hao-xu/dotfiles/blob/main/macos/Brewfile) intentionally contains only the core CLI runtime required by this dotfiles setup. GUI apps, Casks, VS Code extensions, and broader personal-machine restore items are managed outside this install path.
 
     ```shell
     git clone https://github.com/ming-hao-xu/dotfiles.git ~/.dotfiles --recursive
     cd ~/.dotfiles
-    ./install
+    ./install -x
     ```
 
 1. Restart your terminal, and you should be good to go! 🎉  
-   (Ghostty comes pre-installed with JetBrains Mono Nerd Font and Catppuccin Mocha theme. For other terminals, manually install a Nerd Font and apply a Catppuccin Mocha theme.)
+   (This repo links Ghostty config, but it does not install Ghostty. For other terminals, manually install a Nerd Font and apply a Catppuccin Mocha theme.)
+
+## Updating an Existing Machine
+
+```shell
+cd ~/.dotfiles
+git status
+git pull --ff-only
+./install -x
+```
+
+If `git status` shows local changes, review them before pulling. Running `./install -x` will update managed symlinks and install missing core CLI packages, but it will not uninstall old GUI apps, Casks, VS Code extensions, or other machine-local software.
+
+## CI Coverage
+
+CI runs the real installer on macOS 26 with a clean temporary `$HOME`, then reruns it to check idempotency and stale managed-link cleanup. It validates Homebrew bundle installation, Dotbot links, Oh My Zsh plugins, Catppuccin bat/tmux resources, core CLI tools, tmux config loading, and interactive/login zsh startup.
+
+GitHub-hosted macOS runners already provide Homebrew, so the cold Homebrew bootstrap branch remains best-effort and should be manually checked on a truly fresh machine when needed.
 
 ### Optional Steps for macOS
 
@@ -51,6 +68,7 @@ Personal .dotfiles for macOS (Apple Silicon) running zsh
     ```
 
     Uncomment the only line there:
+
     ```shell
     - #auth       sufficient     pam_tid.so
     +  auth       sufficient     pam_tid.so

--- a/macos/install.conf.yaml
+++ b/macos/install.conf.yaml
@@ -65,13 +65,23 @@
         name=$1
         url=$2
         dest=$3
-        if [ ! -d "$dest" ]; then
-          printf 'Installing %s\n' "$name"
-          git clone --quiet --depth 1 "$url" "$dest"
+        shift 3
+
+        if [ -d "$dest/.git" ]; then
+          return 0
         fi
+
+        if [ -e "$dest" ]; then
+          printf '%s exists but is not a git checkout: %s\n' "$name" "$dest" >&2
+          exit 1
+        fi
+
+        printf 'Installing %s\n' "$name"
+        git clone --quiet --depth 1 "$@" "$url" "$dest"
       }
 
       clone_repo "Oh My Zsh" https://github.com/ohmyzsh/ohmyzsh.git "$HOME/.oh-my-zsh"
+      test -f "$HOME/.oh-my-zsh/oh-my-zsh.sh"
       clone_repo "autoupdate plugin" https://github.com/TamCore/autoupdate-oh-my-zsh-plugins "$HOME/.oh-my-zsh/custom/plugins/autoupdate"
       clone_repo "you-should-use plugin" https://github.com/MichaelAquilina/zsh-you-should-use.git "$HOME/.oh-my-zsh/custom/plugins/you-should-use"
       clone_repo "zsh-autosuggestions plugin" https://github.com/zsh-users/zsh-autosuggestions "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
@@ -86,7 +96,5 @@
       fi
       bat cache --build >/dev/null
 
-      if [ ! -d "$HOME/.local/share/tmux/plugins/catppuccin/tmux" ]; then
-        printf '%s\n' 'Installing Catppuccin tmux theme'
-        git -c advice.detachedHead=false clone --quiet --depth 1 --branch v2.3.0 https://github.com/catppuccin/tmux.git "$HOME/.local/share/tmux/plugins/catppuccin/tmux"
-      fi
+      clone_repo "Catppuccin tmux theme" https://github.com/catppuccin/tmux.git "$HOME/.local/share/tmux/plugins/catppuccin/tmux" --branch v2.3.0
+      test -f "$HOME/.local/share/tmux/plugins/catppuccin/tmux/catppuccin.tmux"


### PR DESCRIPTION
## Summary
- update README to describe managed relinks, backups, existing-machine updates, and the core Brewfile boundary
- document the CI coverage boundary for clean HOME installs with runner-provided Homebrew
- make external resource cloning fail fast when a target path exists but is not a git checkout

## Validation
- YAML parse for workflow and Dotbot config
- shell syntax check for Dotbot shell blocks
- Prettier 3.6.2 check for README/YAML
- temporary HOME install smoke with external resource clones
- temporary HOME fail-fast smoke for a partial Oh My Zsh directory

## Notes
- This intentionally does not change the fzf VS Code binding.
- This intentionally does not add Homebrew cold-bootstrap test indirection.
- `advice.detachedHead=false` is not added to this repo config; tag checkout advice may appear for the Catppuccin tmux clone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installer behavior, emphasizing personal-use intent and detailing how it relinks symlinks, removes stale links, and backs up conflicts
  * Added guidance on updating existing machines and documented CI validation coverage
  
* **Chores**
  * Enhanced installation script with stricter handling of pre-existing paths and improved verification steps for dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->