### PR TITLE
Fix zsh syntax validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file("macos/install.conf.yaml")'
+          ruby -e 'require "yaml"; YAML.load_file("macos/install.conf.yaml")'
           bash -n install
-          zsh -n \
-            config/zsh/.zshenv \
-            config/zsh/.zprofile \
-            config/zsh/.zshrc \
-            config/zsh/aliases.zsh \
-            config/zsh/functions.zsh \
-            config/zsh/keybindings.zsh \
+          zsh_files=(
+            config/zsh/.zshenv
+            config/zsh/.zprofile
+            config/zsh/.zshrc
+            config/zsh/aliases.zsh
+            config/zsh/functions.zsh
+            config/zsh/keybindings.zsh
             config/fzf/fzf.zsh
+          )
+
+          for file in "${zsh_files[@]}"; do
+            zsh -n "$file"
+          done
 
       - name: Install dotfiles
         shell: bash


### PR DESCRIPTION
## Summary
- validate only the Dotbot install YAML explicitly in CI
- run `zsh -n` once per zsh/fzf file so every file is actually parsed

## Validation
- ruby YAML parse for `.github/workflows/ci.yml` and `macos/install.conf.yaml`
- `bash -n install`
- local per-file `zsh -n` loop
- `npx --yes prettier@3.6.2 --check .github/workflows/ci.yml macos/install.conf.yaml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal validation processes for the development workflow, enhancing reliability of automated checks during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->