### PR TITLE
Harden dotfiles installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$HOME"
+          mkdir -p "$HOME/.config/git"
+          old_git_config_target="$PWD/config/git"
+          new_git_config_target="$PWD/config/git/config"
+          ln -s "$old_git_config_target" "$HOME/.config/git/config"
           ./install -x
+          test "$(readlink "$HOME/.config/git/config")" = "$new_git_config_target"
 
       - name: Rerun installer
         shell: bash
@@ -62,6 +67,11 @@ jobs:
         run: |
           set -euo pipefail
           ln -s "$PWD/config/dotfiles-ci-missing-target" "$HOME/.config/dotfiles-ci-stale-link"
+          chmod 777 \
+            "$HOME/.cache/zsh" \
+            "$HOME/.cache/oh-my-zsh" \
+            "$HOME/.local/state/zsh" \
+            "$HOME/.local/share/tmux/plugins/catppuccin"
           ./install -x
           test ! -L "$HOME/.config/dotfiles-ci-stale-link"
 
@@ -88,6 +98,22 @@ jobs:
 
           test ! -e "$HOME/.zshrc"
           test -f "$HOME/.oh-my-zsh/oh-my-zsh.sh"
+
+          test "$(stat -f '%Lp' "$HOME/.ssh")" = "700"
+          managed_dirs=(
+            "$HOME/.cache/zsh"
+            "$HOME/.cache/oh-my-zsh"
+            "$HOME/.local/state/zsh"
+            "$HOME/.local/share/tmux/plugins/catppuccin"
+          )
+
+          for dir in "${managed_dirs[@]}"; do
+            mode="$(stat -f '%Lp' "$dir")"
+            if (( (8#$mode & 0022) != 0 )); then
+              echo "::error::$dir has insecure permissions: $mode"
+              exit 1
+            fi
+          done
 
           ruby <<'RUBY'
           require "yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           set -euo pipefail
           ln -s "$PWD/config/dotfiles-ci-missing-target" "$HOME/.config/dotfiles-ci-stale-link"
           chmod 777 \
+            "$HOME/.ssh" \
             "$HOME/.cache/zsh" \
             "$HOME/.cache/oh-my-zsh" \
             "$HOME/.local/state/zsh" \

--- a/install
+++ b/install
@@ -26,6 +26,8 @@ case "${PROFILE}" in
         ;;
 esac
 
-git submodule update --init --recursive "${DOTBOT_DIR}"
+if ! git submodule update --init --recursive "${DOTBOT_DIR}"; then
+    GIT_CONFIG_GLOBAL=/dev/null git submodule update --init --recursive "${DOTBOT_DIR}"
+fi
 
 "${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" -c "${CONFIG}" "${@}"

--- a/macos/install.conf.yaml
+++ b/macos/install.conf.yaml
@@ -3,10 +3,49 @@
       create: true
       relink: true
       backup: true
+    create:
+      mode: 0755
     shell:
       stdout: true
       stderr: true
       quiet: true
+
+- create:
+    ~/.ssh:
+      mode: 0700
+    ~/.cache/zsh:
+    ~/.cache/oh-my-zsh:
+    ~/.local/state/zsh:
+    ~/.local/share/tmux/plugins/catppuccin:
+
+- shell:
+    - command: |
+        set -e
+        chmod go-w \
+          "$HOME/.cache/zsh" \
+          "$HOME/.cache/oh-my-zsh" \
+          "$HOME/.local/state/zsh" \
+          "$HOME/.local/share/tmux/plugins/catppuccin"
+      description: Secure managed directories
+
+- clean:
+    ~/:
+    ~/.config:
+      recursive: true
+
+- link:
+    ~/.zshenv: config/zsh/.zshenv
+    ~/.config/zsh: config/zsh
+    ~/.config/bat/config: config/bat/config
+    ~/.config/starship/starship.toml: config/starship/starship.toml
+    ~/.config/ghostty/config: config/ghostty/config
+    ~/.hushlogin: config/hushlogin
+    ~/.config/tmux/tmux.conf: config/tmux/tmux.conf
+    ~/.config/git/config: config/git/config
+    ~/.config/fd/ignore: macos/config/fd/ignore
+    ~/.config/gh/config.yml: config/gh/config.yml
+    ~/.config/homebrew/brew.env: config/homebrew/brew.env
+    ~/.config/fzf/fzf.zsh: config/fzf/fzf.zsh
 
 - shell:
     - command: |
@@ -29,35 +68,6 @@
         brew bundle install --file="${DOTFILES_BREWFILE:-macos/Brewfile}"
         brew completions link >/dev/null
       description: Install Homebrew packages
-
-- create:
-    ~/.ssh:
-      mode: 0700
-    ~/.cache/zsh:
-    ~/.cache/oh-my-zsh:
-    ~/.local/state/zsh:
-    ~/.local/share/tmux/plugins/catppuccin:
-
-- clean:
-    ~/:
-    ~/.config:
-      recursive: true
-
-- link:
-    ~/.zshenv: config/zsh/.zshenv
-    ~/.config/zsh: config/zsh
-    ~/.config/bat/config: config/bat/config
-    ~/.config/starship/starship.toml: config/starship/starship.toml
-    ~/.config/ghostty/config: config/ghostty/config
-    ~/.hushlogin: config/hushlogin
-    ~/.config/tmux/tmux.conf: config/tmux/tmux.conf
-    ~/.config/git/config: config/git/config
-    ~/.config/fd/ignore: macos/config/fd/ignore
-    ~/.config/gh/config.yml: config/gh/config.yml
-    ~/.config/homebrew/brew.env: config/homebrew/brew.env
-    ~/.config/fzf/fzf.zsh: config/fzf/fzf.zsh
-
-- shell:
     - |
       set -e
 

--- a/macos/install.conf.yaml
+++ b/macos/install.conf.yaml
@@ -21,6 +21,7 @@
 - shell:
     - command: |
         set -e
+        chmod 0700 "$HOME/.ssh"
         chmod go-w \
           "$HOME/.cache/zsh" \
           "$HOME/.cache/oh-my-zsh" \


### PR DESCRIPTION
## Summary
- make Dotbot bootstrap independent of broken user-level Git config
- run create/clean/link before Homebrew and external resource setup
- set managed create defaults to 0755 and repair permissions for `~/.ssh` plus managed cache/state/plugin directories
- extend CI to cover the old git config symlink migration, rerun permission repair, and existing `~/.ssh` mode repair

## Validation
- ruby YAML parse for `.github/workflows/ci.yml` and `macos/install.conf.yaml`
- `bash -n install`
- per-file `zsh -n` loop
- `git diff --check`
- targeted temporary-HOME checks for create modes, repairing `~/.ssh`/777 managed directories, and Git bootstrap with a broken global config path
- `npx --yes prettier@3.6.2 --check .github/workflows/ci.yml macos/install.conf.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores / Tests**
  * Extended macOS installer validation to set up and verify the Git config symlink target.
  * Hardened security checks by enforcing safe permissions for sensitive directories and failing on overly permissive group/other write access.
* **Chores**
  * Improved install resilience by conditionally retrying submodule initialization without relying on global Git configuration.
* **Configuration**
  * Updated macOS install configuration to standardize directory creation modes, centralize Homebrew bootstrap steps, and normalize managed directory/SSH permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
